### PR TITLE
Show sizes of unique modules

### DIFF
--- a/bin/analytics.rs
+++ b/bin/analytics.rs
@@ -64,6 +64,7 @@ fn compare_objects(left: &HashMap<String, Module>, right: &HashMap<String, Modul
         diff.sort();
         for unique in diff {
             println!("\tL- {}", unique);
+            println!("\t\t{}", left.get(*unique).unwrap());
         }
 
         println!("Objects unique to right...");
@@ -71,6 +72,7 @@ fn compare_objects(left: &HashMap<String, Module>, right: &HashMap<String, Modul
         diff.sort();
         for unique in diff {
             println!("\tR- {}", unique);
+            println!("\t\t{}", right.get(*unique).unwrap());
         }
     } else {
         println!("No unique objects between left and right");

--- a/bin/analytics.rs
+++ b/bin/analytics.rs
@@ -64,7 +64,7 @@ fn compare_objects(left: &HashMap<String, Module>, right: &HashMap<String, Modul
         diff.sort();
         for unique in diff {
             println!("\tL- {}", unique);
-            println!("\t\t{}", left.get(*unique).unwrap());
+            println!("\t   {}", left.get(*unique).unwrap());
         }
 
         println!("Objects unique to right...");
@@ -72,7 +72,7 @@ fn compare_objects(left: &HashMap<String, Module>, right: &HashMap<String, Modul
         diff.sort();
         for unique in diff {
             println!("\tR- {}", unique);
-            println!("\t\t{}", right.get(*unique).unwrap());
+            println!("\t   {}", right.get(*unique).unwrap());
         }
     } else {
         println!("No unique objects between left and right");
@@ -90,9 +90,9 @@ fn compare_objects(left: &HashMap<String, Module>, right: &HashMap<String, Modul
 
             no_difference = false;
             println!("Difference in {}...", obj);
-            println!("\t L- {}", l);
-            println!("\t R- {}", r);
-            println!("\t D- {}", *l - *r);
+            println!("\tL- {}", l);
+            println!("\tR- {}", r);
+            println!("\tD- {}", *l - *r);
         }
     }
 

--- a/bin/analytics.rs
+++ b/bin/analytics.rs
@@ -79,7 +79,9 @@ fn compare_objects(left: &HashMap<String, Module>, right: &HashMap<String, Modul
     }
 
     let mut no_difference = true;
-    for obj in lkeys.intersection(&rkeys) {
+    let mut intersect: Vec<_> = lkeys.intersection(&rkeys).collect();
+    intersect.sort();
+    for obj in intersect {
         let l = left.get(*obj);
         let r = right.get(*obj);
 

--- a/src/summary/module.rs
+++ b/src/summary/module.rs
@@ -21,7 +21,7 @@ use std::fmt;
 /// let a = Module{ ro_code: Some(10), ro_data: None, rw_data: Some(20) };
 /// let b = Module{ ro_code: Some(5), ro_data: Some(4), rw_data: Some(11) };
 ///
-/// let expected = Module{ ro_code: Some(5), ro_data: None, rw_data: Some(9) };
+/// let expected = Module{ ro_code: Some(5), ro_data: Some(-4), rw_data: Some(9) };
 /// assert_eq!(a - b, expected);
 /// ```
 ///
@@ -50,12 +50,15 @@ impl Module {
     }
 }
 
-/// Subtract two optional values iff both values exist.
+/// Subtract two optional values, counting None as "0" if the other value is
+/// Some(v)
 #[inline]
 fn optional_diff(left: Option<i32>, right: Option<i32>) -> Option<i32> {
     match (left, right) {
         (Some(l), Some(r)) => Some(l - r),
-        _ => None,
+        (Some(l), None) => Some(l),
+        (None, Some(r)) => Some(-r),
+        (None, None) => None
     }
 }
 


### PR DESCRIPTION
The PR updates the mapcmp binary to show the sizes of the unique modules. The PR also improves the utility to show differences if one size is not available in another.